### PR TITLE
css reset style

### DIFF
--- a/css-reset-by-class.css
+++ b/css-reset-by-class.css
@@ -2,12 +2,14 @@
 body {
     margin: 0;
     overflow-wrap: break-word;
+    -webkit-text-size-adjust: none;
+    text-size-adjust: none;
 }
 
 /* Do not break Korean words */
 :lang(ko) { word-break: keep-all; }
 
-/* Reset img */
+/* Reset by Type selectors */
 img {
     max-width: 100%;
     height: auto;
@@ -29,7 +31,7 @@ img {
 [class]::before,
 [class]::after { box-sizing: border-box; }
 
-/* CSS Reset by [class] - Will be used when Samsung Internet supports it.
+/*CSS Reset by [class] - Will be used when Samsung Internet supports it.*/
 [class] {
   margin: 0;
   padding: 0;
@@ -39,6 +41,8 @@ img {
 [class]::after { box-sizing: border-box; }
 [class]:where(ol, ul) { list-style: none; }
 [class]:where(button, fieldset, iframe, input, select, textarea) { border: 0; }
+[class]:where(iframe){overflow: hidden;}
+[class]:where(textarea){resize: vertical;}
 [class]:where(button, dialog, input, mark, meter, progress) { background-color: transparent; }
 [class]:where(table) {
   border: 0;
@@ -49,4 +53,3 @@ img {
   -webkit-appearance: none;
   appearance: none;
 }
-*/


### PR DESCRIPTION
안녕하세요. 마크업 가이드 강의 수강중인 허성은 수강생입니다.
실습과제를 겸하여 PR 드립니다.

1. class에 의한 리셋을 추가하였습니다.
[class]:where(iframe){overflow: hidden;}
[class]:where(textarea){resize: vertical;}
Reset by Type selectors 로 img 태그와 함께 추가하려하다 iframe과 textarea는 비교적 적게 사용되는 타입이라고 생각되어 
고민끝에 :where 를 사용하여 추가했습니다.

2. body에 -webkit-text-size-adjust: none; text-size-adjust: none; 을 추가하였습니다.

이 외에도 추가하고 싶었으나 잘 사용되지 않거나(hr, u, b 등), 모든 프로젝트 들에 보편적으로 적용하기 어렵거나(input type 별 스타일들,:-ms-clear 등), 이미 작성되어있어 위의 항목만 우선적으로 PR드리게 되었습니다.

습관적으로 사용하던 css reset style에 대해 고민해볼 수 있는 기회를 가질 수 있게되어 뜻깊은 챕터였습니다.
마크업 가이드 강의를 들으며 많은 배움을 얻고있습니다. 

부족한 부분이나 간과한 부분이 있다면 피드백 부탁드리며, 
좋은 강의를 제작해주셔서 감사합니다.